### PR TITLE
Limit number of time API is called

### DIFF
--- a/AlphaVantage.Net/src/AlphaVantage.Net.Core/InternalHttpClient/HttpClientWithRateLimit.cs
+++ b/AlphaVantage.Net/src/AlphaVantage.Net.Core/InternalHttpClient/HttpClientWithRateLimit.cs
@@ -54,12 +54,12 @@ namespace AlphaVantage.Net.Core.InternalHttpClient
                     delayInterval = _minRequestInterval - timeSinceLastRequest;
                 }
                 _previousRequestStartTime = DateTime.Now;
-                if (delayInterval != null)
+                if (delayInterval.HasValue)
                 {
                     _previousRequestStartTime.AddMilliseconds(delayInterval.Value.Milliseconds);
                 }
             }
-            if (delayInterval != null)
+            if (delayInterval.HasValue)
             {
                 await Task.Delay(delayInterval.Value.Milliseconds);
             }

--- a/AlphaVantage.Net/src/AlphaVantage.Net.Core/InternalHttpClient/HttpClientWithRateLimit.cs
+++ b/AlphaVantage.Net/src/AlphaVantage.Net.Core/InternalHttpClient/HttpClientWithRateLimit.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AlphaVantage.Net.Core.InternalHttpClient
+{
+    /// <summary>
+    /// Only requests passing thru given instance of the client are throttled.
+    /// Two different instances of the client may have totally different rate limites.
+    /// </summary>
+    internal class HttpClientWithRateLimit : IHttpClient, IDisposable
+    {
+        private HttpClient _client;
+        private TimeSpan _minRequestInterval;//Calculated based on rpm limit in constructor
+        private Semaphore _concurrentRequestsCounter;
+        private DateTime _previousRequestStartTime;
+        private Object _lockObject = new Object();
+        internal HttpClientWithRateLimit(HttpClient client, int maxRequestPerMinutes, int maxConcurrentRequests)
+        {
+            _client = client;
+            _minRequestInterval = new TimeSpan(0, 0, 0, 0, 60000 / maxRequestPerMinutes);
+            _concurrentRequestsCounter = new Semaphore(maxConcurrentRequests, maxConcurrentRequests);
+            _previousRequestStartTime = DateTime.MinValue;
+        }
+        public void Dispose()
+        {
+            _concurrentRequestsCounter.Dispose();
+        }
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
+        {
+            HttpResponseMessage response = null;
+            _concurrentRequestsCounter.WaitOne();
+            await WaitForRequestedMinimumInterval();
+            try
+            {
+                response = await _client.SendAsync(request);
+            }
+            catch
+            {
+                _concurrentRequestsCounter.Release();
+                throw;
+            }
+            return response;
+        }
+        private async Task WaitForRequestedMinimumInterval()
+        {
+            TimeSpan? delayInterval = null;
+            lock (_lockObject)
+            {
+                var timeSinceLastRequest = DateTime.Now - _previousRequestStartTime;
+                if (timeSinceLastRequest < _minRequestInterval)
+                {
+                    delayInterval = _minRequestInterval - timeSinceLastRequest;
+                }
+                _previousRequestStartTime = DateTime.Now;
+                if (delayInterval != null)
+                {
+                    _previousRequestStartTime.AddMilliseconds(delayInterval.Value.Milliseconds);
+                }
+            }
+            if (delayInterval != null)
+            {
+                await Task.Delay(delayInterval.Value.Milliseconds);
+            }
+        }
+        public void SetTimeOut(TimeSpan timeSpan)
+        {
+            _client.Timeout = timeSpan;
+        }
+    }
+}

--- a/AlphaVantage.Net/src/AlphaVantage.Net.Core/InternalHttpClient/IHttpClient.cs
+++ b/AlphaVantage.Net/src/AlphaVantage.Net.Core/InternalHttpClient/IHttpClient.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace AlphaVantage.Net.Core.InternalHttpClient
+{
+    internal interface IHttpClient
+    {
+        void SetTimeOut(TimeSpan timeSpan);
+        Task<HttpResponseMessage> SendAsync(HttpRequestMessage request);
+    }
+}


### PR DESCRIPTION
Work is done on issues #2 and #3 

Rate limit are hard coded.
Do you think user should now or in future have option to change this value? We have two options here.

1. Declared 'IHttpClient _client' as static variable(As it is done here), so requests from all instances of AlphaVantageCoreClient will be counted towards rate limit. In future, if we want to add an option to allow user to set rate limit for client, then we will have to expose static method on AlphaVantageCoreClient.

1. If we make 'IHttpClient _client' instance variable, then user will have to make sure that they pass all their request to single instance of 'AlphaVantageCoreClient'. Otherwise rate limit will not be respected, since each instance will have its own rate limit.

With approach 1, user cannot create two AlphaVantageCoreClients with different rate limits. With approach 2, user will will have to manage single instance of AlphaVantageCoreClient.